### PR TITLE
fix: 补充路径说明，避免使用最新 NPM 包时报错

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -24,8 +24,9 @@ Proxy地址为 http://${IP}:9000
 
 ## 接口使用方法
 
-1. 将 openai 的请求地址（ https://api.openai.com ）变更为本 proxy 的地址（ 不带斜杠 ）
-1. 如果设置了PROXY_KEY，在 openai 的 key 后加上 `:<PROXY_KEY>`，如果没有设置，则不需修改
+1. 将 openai 的请求地址（ https://api.openai.com ）变更为本 proxy 的地址加上 "v1"（ 不带斜杠 ）
+   - 举例： `http://${IP}:9000/v1`
+2. 如果设置了PROXY_KEY，在 openai 的 key 后加上 `:<PROXY_KEY>`，如果没有设置，则不需修改
 
 ## 说明 
 
@@ -39,7 +40,7 @@ Proxy地址为 http://${IP}:9000
 ```js
 chatApi= new gpt.ChatGPTAPI({
     apiKey: 'sk.....:<proxy_key写这里>',
-    apiBaseUrl: "http://localhost:9001", // 传递代理地址
+    apiBaseUrl: "http://localhost:9001/v1", // 传递代理地址
 });
    
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The proxy address is http://${IP}:9000.
 
 ## Usage of the API
 
-1. Change the request address of OpenAI (https://api.openai.com) to the address of this proxy (without a slash).
+1. Change the request address of OpenAI (https://api.openai.com) to the address of this proxy with the addition of "v1" (without a slash).
+   - Example: `http://${IP}:9000/v1`
 2. If PROXY_KEY is set, add `:<PROXY_KEY>` after the OpenAI key. If not set, no modification is required.
 
 ## Explanation
@@ -50,7 +51,7 @@ Take `https://www.npmjs.com/package/chatgpt` as an example.
 ```js
 chatApi= new gpt.ChatGPTAPI({
     apiKey: 'sk.....:<proxy_key here>',
-    apiBaseUrl: "http://localhost:9001", // Pass the proxy address
+    apiBaseUrl: "http://localhost:9001/v1", // Pass the proxy address
 });
 
 ```


### PR DESCRIPTION
在使用 `chatgpt` 这个 NPM 包时，`apiBaseUrl` 需要指定子路径 `/v1`，否则会遇到诸如 `invalid_request_error` 一类的报错。希望修正 README 中的说明，避免使用者踩坑。

具体可参考 `chatgpt` 中 `apiBaseUrl` 的默认值设定：https://github.com/transitive-bullshit/chatgpt-api/blob/main/src/chatgpt-api.ts#L52