### PR TITLE
feat: support CORS in docker version

### DIFF
--- a/docker/app.js
+++ b/docker/app.js
@@ -5,6 +5,8 @@ const app = express()
 var multer = require('multer');
 var forms = multer({limits: { fieldSize: 10*1024*1024 }});
 app.use(forms.array()); 
+const cors = require('cors');
+app.use(cors());
 
 const bodyParser = require('body-parser')
 app.use(bodyParser.json({limit : '50mb' }));  

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
     "cross-fetch": "^3.1.5",
     "eventsource-parser": "^0.1.0",
     "express": "^4.18.2",


### PR DESCRIPTION
部分工具（如 OpenAI Translate）实际是由 Web 页面发起请求，因此会首先发起 OPTIONS 请求。如果直接拒绝会导致无法使用。