### PR TITLE
处理SSE 4xx/5xx错误

### DIFF
--- a/app.js
+++ b/app.js
@@ -218,6 +218,10 @@ app.all(`*`, async (req, res) => {
             parser.feed(str);
           }
         }
+      }else
+      {
+        const body = await response.text();
+        res.status(response.status).send(body);
       }
       
     }else

--- a/docker/app.js
+++ b/docker/app.js
@@ -218,6 +218,10 @@ app.all(`*`, async (req, res) => {
             parser.feed(str);
           }
         }
+      }else
+      {
+        const body = await response.text();
+        res.status(response.status).send(body);
       }
       
     }else


### PR DESCRIPTION
使用 `stream: true` 时，对于 OpenAI API 返回 4xx 或 5xx 错误的情况，原项目没有做任何处理，会导致连接挂起，直到客户端超时关闭连接。例如，在 API key 无效且启用流式输出时：

```http
POST http://127.0.0.1:9000/v1/chat/completions
Authorization: Bearer sk-false
Content-Type: application/json

{
  "model": "gpt-3.5-turbo",
  "messages": [{"role": "user", "content": "Say this is a test!"}],
  "stream": true
}
```

OpenAI API 的返回：

```http
HTTP/2 401
date: Mon, 08 May 2023 06:08:20 GMT
content-type: application/json; charset=utf-8
content-length: 258
vary: Origin
x-request-id: 7b966b36ddd38909e4767811c768ed99
strict-transport-security: max-age=15724800; includeSubDomains
cf-cache-status: DYNAMIC
server: cloudflare
cf-ray: 7c3f8710cf8b40f0-SIN
alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400

{
    "error": {
        "message": "Incorrect API key provided: sk-false. You can find your API key at https://platform.openai.com/account/api-keys.",
        "type": "invalid_request_error",
        "param": null,
        "code": "invalid_api_key"
    }
}
```

openai-api-proxy 的返回：没有返回任何内容，一直到连接超时。

> 注：同样的错误，在不启用流式输出时 OpenAI 使用的是状态码 `200 OK`。
